### PR TITLE
fix(ci): green up main — Pages, Scorecard, Trusted Publishing, CodeQL

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -84,8 +84,13 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: "https://registry.npmjs.org/"
+
+      # Trusted Publishing requires npm CLI >= 11.5.1 (the OIDC client).
+      # Node 22 ships npm 10.x, so install the latest npm explicitly.
+      - name: Upgrade npm to latest (Trusted Publishing OIDC support)
+        run: npm install -g npm@latest
 
       - name: Download build artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -98,9 +103,14 @@ jobs:
           mkdir -p dist
           tar -xzf *.tgz --strip-components=1 -C dist
 
-      - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # No NODE_AUTH_TOKEN — npm CLI exchanges the GitHub OIDC token
+      # for a short-lived publish credential via Trusted Publishing.
+      # Configure once on npmjs.com:
+      #   package → Settings → Trusted Publishers → GitHub Actions
+      #     org/user:  sebastienrousseau
+      #     repo:      skeletonic-stylus
+      #     workflow:  npm-publish.yml
+      - name: Publish to npm via Trusted Publishing (OIDC)
         run: npm publish ./dist --access public --provenance
 
       - name: Verify CDN availability (jsDelivr + unpkg)

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Install Playwright Chromium for a11y test
+        run: pnpm exec playwright install --with-deps chromium
+
       - name: Build
         run: pnpm run build
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@ea651e62978af7915d09fe2e282747c798bf2dab  # v2.4.1
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/scripts/cli.mjs
+++ b/scripts/cli.mjs
@@ -194,12 +194,16 @@ function cmdAdd(name) {
   const cwd = process.cwd();
   const targetDir = join(cwd, "styles", "components");
   const targetFile = join(targetDir, `${name}.styl`);
-  if (existsSync(targetFile)) {
-    fail(`${relPath(targetFile)} already exists. Refusing to overwrite.`);
-    return 1;
-  }
   ensureDir(targetDir);
-  writeFileSync(targetFile, readFileSync(src, "utf8"), "utf8");
+  try {
+    writeFileSync(targetFile, readFileSync(src, "utf8"), { encoding: "utf8", flag: "wx" });
+  } catch (err) {
+    if (err.code === "EEXIST") {
+      fail(`${relPath(targetFile)} already exists. Refusing to overwrite.`);
+      return 1;
+    }
+    throw err;
+  }
   ok(`copied ${name}.styl → ${relPath(targetFile)}`);
   return 0;
 }

--- a/scripts/verify-cdn.mjs
+++ b/scripts/verify-cdn.mjs
@@ -28,7 +28,22 @@ const pkgPath = existsSync(join(repoRoot, "dist/package.json"))
   ? join(repoRoot, "dist/package.json")
   : join(repoRoot, "package.json");
 const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
-const { name, version } = pkg;
+
+// Validate package metadata against an allowlist before constructing
+// any outbound URL. Refuses to ping a CDN for an unexpected name or a
+// non-semver version, which closes a file-controlled-URL surface.
+const ALLOWED_NAME = "@sebastienrousseau/skeletonic-stylus";
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+if (pkg.name !== ALLOWED_NAME) {
+  console.error(`verify-cdn: refusing — unexpected package name: ${JSON.stringify(pkg.name)}`);
+  process.exit(2);
+}
+if (typeof pkg.version !== "string" || !SEMVER_RE.test(pkg.version)) {
+  console.error(`verify-cdn: refusing — invalid semver version: ${JSON.stringify(pkg.version)}`);
+  process.exit(2);
+}
+const name = ALLOWED_NAME;
+const version = pkg.version;
 
 const timeoutMs = Number(process.env.CDN_TIMEOUT_MS || 5 * 60 * 1000);  // 5 min default
 const pollMs = Number(process.env.CDN_POLL_MS || 5000);                 // 5 s polls

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -67,7 +67,13 @@ console.log("\n\x1b[1mverify-release\x1b[0m — pre-release gate\n");
   );
   record("dist/package.json strips dev fields", !["devDependencies", "pnpm", "autoupdate"].some(k => k in dist));
   record("dist/package.json files[] declared", Array.isArray(dist.files) && dist.files.length > 0, dist.files?.join(", "));
-  record("repository URL contains GitHub owner/repo", /github\.com\/sebastienrousseau\/skeletonic-stylus/.test(dist.repository), dist.repository);
+  const repoUrl = (typeof dist.repository === "string" ? dist.repository : dist.repository?.url || "").replace(/^git\+/, "").replace(/\.git$/, "");
+  let repoOk = false;
+  try {
+    const u = new URL(repoUrl);
+    repoOk = u.hostname === "github.com" && u.pathname === "/sebastienrousseau/skeletonic-stylus";
+  } catch { /* malformed URL → fail gate */ }
+  record("repository URL is github.com/sebastienrousseau/skeletonic-stylus", repoOk, repoUrl);
   record("publishConfig.access = public", dist.publishConfig?.access === "public");
   record("license is OSI-recognised", /MIT|Apache|BSD|ISC/i.test(dist.license || ""), dist.license);
 }

--- a/scripts/wrap-cascade-layers.mjs
+++ b/scripts/wrap-cascade-layers.mjs
@@ -23,7 +23,7 @@
  * Cross-platform: pure Node, no shell, runs on macOS / Linux / WSL.
  */
 
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { argv, exit } from "node:process";
 
 const targets = argv.slice(2);
@@ -39,13 +39,16 @@ const layerOrder =
 
 let failed = 0;
 for (const target of targets) {
-  if (!existsSync(target)) {
-    console.error(`wrap-cascade-layers: file not found: ${target}`);
+  let css;
+  try {
+    css = readFileSync(target, "utf8");
+  } catch (err) {
+    console.error(
+      `wrap-cascade-layers: cannot read ${target}: ${err.code || err.message}`,
+    );
     failed++;
     continue;
   }
-
-  const css = readFileSync(target, "utf8");
 
   // Idempotency guard — never double-wrap.
   if (css.includes("@layer skeletonic.reset")) {


### PR DESCRIPTION
## Summary

Surgical hotfix to clear the two failing CI jobs on `main` after the v2.0.0 release, plus close 4 CodeQL alerts and harden `npm publish`. Cherry-picked from `feat/v2.0` — workflow + scripts only, no library or build-output changes.

- **fix(security)** — close 4 CodeQL alerts in `scripts/`:
  - `wrap-cascade-layers.mjs` / `cli.mjs`: drop `existsSync→writeFileSync` TOCTOU; atomic `wx` open and try/catch read.
  - `verify-release.mjs`: replace unanchored `github.com/...` regex with WHATWG `URL` parsing; exact `hostname` + `pathname` match.
  - `verify-cdn.mjs`: allowlist + strict semver gate before constructing any outbound URL (closes file-controlled-URL surface).
- **fix(ci)** — two unrelated workflow failures, fixed together:
  - `pages.yml`: install Playwright Chromium before `pnpm run build` (the a11y gate inside `dev:a11y` was crashing).
  - `scorecard.yml`: repin `ossf/scorecard-action` from a v2.4.1 *annotated tag object* SHA (rejected by the imposter-commit check) to v2.4.3's underlying commit SHA.
- **ci(publish)** — migrate `npm publish` from long-lived `NPM_TOKEN` to OIDC Trusted Publishing:
  - Drop `NODE_AUTH_TOKEN`, bump publish-job Node 20 → 22, add `npm install -g npm@latest` (Trusted Publishing requires npm ≥ 11.5.1; Node 22 ships 10.x).
  - Companion one-time manual step on npmjs.com: package → Settings → Trusted Publishers → GitHub Actions, with org `sebastienrousseau`, repo `skeletonic-stylus`, workflow `npm-publish.yml`, environment blank. Until that's configured the publish step fails with `E_OIDC` by design.

## Test Plan

- [ ] Pages workflow turns green on this PR's `push` to `hotfix/ci-fixes` (and again post-merge on `main`).
- [ ] Scorecard workflow no longer rejects the action SHA as an imposter commit; SARIF upload succeeds.
- [ ] CodeQL alerts on `main` auto-resolve once this lands (4 open: 2× `js/file-system-race`, 1× `js/regex/missing-regexp-anchor`, 1× `js/file-access-to-http`).
- [ ] No accidental library / `dist/` / `package.json` version churn — diff is workflows + scripts only.
- [ ] Next tagged release exercises the OIDC publish path (after Trusted Publisher is configured npm-side).