### PR TITLE
fix(ci): repin upload-sarif to commit SHA (Scorecard imposter check)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -58,6 +58,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF results to code scanning
-        uses: github/codeql-action/upload-sarif@7fc1baf373eb073c686865bd453d412d506a05a2  # v3.35.1
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3.35.1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Follow-up to #177. The Scorecard run on `main` post-merge made it past the previous imposter-commit on `ossf/scorecard-action`, but then failed at the SARIF upload step:

```
imposter commit: 7fc1baf373eb073c686865bd453d412d506a05a2 does not belong to github/codeql-action/upload-sarif
```

Same root cause as before — that SHA is the **annotated tag object** SHA for v3.35.1, not the underlying commit SHA. Repinned to `5c8a8a642e79153f5d047b10ec1cba1d1cc65699`, the commit the v3.35.1 tag dereferences to (`gh api repos/github/codeql-action/git/tags/7fc1baf… → object.type=commit`). Same v3.35.1 release, just the right object type.

Audited the other two pins in `scorecard.yml` (`actions/checkout`, `actions/upload-artifact`) — both are already commit SHAs, so this is the last of the kind in this workflow.

## Test Plan

- [ ] PR's own checks pass (build / CodeQL / Codacy / Snyk).
- [ ] Once merged, the next push-to-main Scorecard run completes without the `imposter commit` rejection and the SARIF upload to code scanning succeeds.