### PR TITLE
fix(ci): bump publish job to Node 24, drop broken npm self-upgrade

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -84,13 +84,13 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: 22
+          # Node 24 ships npm 11.12+ which already meets Trusted
+          # Publishing's >= 11.5.1 OIDC-client minimum, so no in-place
+          # `npm install -g npm@latest` upgrade is needed.  Avoiding
+          # that step also sidesteps a known npm-self-upgrade race
+          # where arborist drops `promise-retry` mid-rebuild.
+          node-version: 24
           registry-url: "https://registry.npmjs.org/"
-
-      # Trusted Publishing requires npm CLI >= 11.5.1 (the OIDC client).
-      # Node 22 ships npm 10.x, so install the latest npm explicitly.
-      - name: Upgrade npm to latest (Trusted Publishing OIDC support)
-        run: npm install -g npm@latest
 
       - name: Download build artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4


### PR DESCRIPTION
## Summary

The v2.0.0 publish attempt (run [25288357513](https://github.com/sebastienrousseau/skeletonic-stylus/actions/runs/25288357513)) failed at the `npm install -g npm@latest` step with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

Known npm self-upgrade race: arborist deletes the old `node_modules` tree before fully linking the new one, and a rebuild step looks up `promise-retry` while it's between trees.

Cleaner fix than retrying or pinning a workaround version: don't upgrade in-place at all. Bump the publish job to Node 24 (currently 24.15.0, ships npm 11.12.1 — above Trusted Publishing's 11.5.1 OIDC-client floor) and drop the broken upgrade step entirely.

Build matrix (Node 20 + 22) is unchanged — those jobs don't publish.

## Test Plan

- [ ] PR's own CI passes (build / CodeQL / Codacy / Snyk).
- [ ] Once merged + v2.0.0 re-tagged at the new commit, the publish job: completes the OIDC token exchange, publishes `@sebastienrousseau/skeletonic-stylus@2.0.0` with `--provenance`, polls jsDelivr + unpkg until both serve 200, and opens a draft GitHub release.