### PR TITLE
chore(actions): bump every action to a Node 24 release

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,18 +27,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3.35.1
+      uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
       with:
         languages: ${{ matrix.language }}
         queries: security-extended
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3.35.1
+      uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3.35.1
+      uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -36,15 +36,15 @@ jobs:
         node-version: [20, 22]
     steps:
       - name: Check out repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
+        uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a  # v6
         with:
           version: 9
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload package artifact
         if: matrix.node-version == 20
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: skeletonic-stylus-package
           path: '*.tgz'
@@ -82,7 +82,7 @@ jobs:
       id-token: write
     steps:
       - name: Use Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           # Node 24 ships npm 11.12+ which already meets Trusted
           # Publishing's >= 11.5.1 OIDC-client minimum, so no in-place
@@ -93,7 +93,7 @@ jobs:
           registry-url: "https://registry.npmjs.org/"
 
       - name: Download build artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: skeletonic-stylus-package
           path: .
@@ -149,7 +149,7 @@ jobs:
           '
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3
         with:
           draft: true
           prerelease: false

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
+        uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a  # v6
         with:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "20"
           cache: "pnpm"
@@ -42,10 +42,10 @@ jobs:
         run: pnpm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d  # v4
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5
         with:
           path: './dist'
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,7 +39,7 @@ jobs:
       actions: read
     steps:
       - name: Check out repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           persist-credentials: false
 
@@ -51,13 +51,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload SARIF results to code scanning
-        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3.35.1
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

GitHub is forcing Node 20 actions onto Node 24 by default from **2026-06-02** — every recent run has the banner. Cleared by bumping each action to the first major release whose `runs.using` is `node24` (or `composite`).

| Workflow | Action | Before → After |
|---|---|---|
| `npm-publish.yml` | actions/checkout | v4 → **v6** |
| `npm-publish.yml` | pnpm/action-setup | v4 → **v6** |
| `npm-publish.yml` | actions/setup-node | v4 → **v6** |
| `npm-publish.yml` | actions/upload-artifact | v4 → **v7** |
| `npm-publish.yml` | actions/download-artifact | v4 → **v8** |
| `npm-publish.yml` | softprops/action-gh-release | v2 → **v3** |
| `pages.yml` | actions/checkout | v4 → **v6** |
| `pages.yml` | pnpm/action-setup | v4 → **v6** |
| `pages.yml` | actions/setup-node | v4 → **v6** |
| `pages.yml` | actions/configure-pages | v4 → **v6** |
| `pages.yml` | actions/upload-pages-artifact | v3 → **v5** |
| `pages.yml` | actions/deploy-pages | v4 → **v5** |
| `codeql.yml` | actions/checkout | v4 → **v6** |
| `codeql.yml` | github/codeql-action/{init,autobuild,analyze} | v3.35.1 → **v4.35.3** |
| `scorecard.yml` | actions/checkout | v4 → **v6** |
| `scorecard.yml` | actions/upload-artifact | v4 → **v7** |
| `scorecard.yml` | github/codeql-action/upload-sarif | v3.35.1 → **v4.35.3** |

Untouched: `ossf/scorecard-action` (Docker-runner, not affected); the build-matrix `node-version: [20, 22]` and publish-job `node-version: 24` (those are *user* Node versions for `pnpm test` / `npm publish`, separate concern).

## Imposter-SHA hygiene

All new SHAs verified to be commit SHAs, not annotated-tag SHAs (same trap fixed in #178). Three pins were annotated tags upstream (`pnpm/action-setup@v6`, `github/codeql-action/*@v4.35.3`) — those were dereferenced via `gh api .../git/refs/tags/<tag>` → `git/tags/<sha>` → `object.sha` before pinning.

## Test Plan

- [ ] PR's own checks (build / CodeQL / Codacy / Snyk) all pass on the upgraded actions.
- [ ] Post-merge: next push-to-main runs of Pages, CodeQL, and Scorecard go green without Node 20 deprecation banners.
- [ ] Future tag pushes for v2.0.x exercise the new `actions/setup-node@v6`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, and `softprops/action-gh-release@v3` end-to-end.