### PR TITLE
chore(deps): consolidate dependency updates for v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastienrousseau/skeletonic-stylus",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A lightweight, intuitive, accessible and ultra-responsive Stylus Library to streamline your digital and mobile web development needs. Proudly made with Stylus ❤",
   "keywords": [
     "css",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         version: 12.1.0(size-limit@12.1.0(jiti@2.6.1))
       autoprefixer:
         specifier: ^10.5.0
-        version: 10.5.0(postcss@8.5.13)
+        version: 10.5.0(postcss@8.5.18)
       clean-css-cli:
         specifier: ^5.6.3
         version: 5.6.3
@@ -56,13 +56,13 @@ importers:
         version: 1.59.1
       postcss:
         specifier: ^8.5.13
-        version: 8.5.13
+        version: 8.5.18
       postcss-cli:
         specifier: ^11.0.1
-        version: 11.0.1(jiti@2.6.1)(postcss@8.5.13)
+        version: 11.0.1(jiti@2.6.1)(postcss@8.5.18)
       postcss-sorting:
         specifier: ^10.0.0
-        version: 10.0.0(postcss@8.5.13)
+        version: 10.0.0(postcss@8.5.18)
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -1125,8 +1125,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1327,8 +1327,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.13:
-    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier-linter-helpers@1.0.1:
@@ -2217,13 +2217,13 @@ snapshots:
 
   async@1.5.2: {}
 
-  autoprefixer@10.5.0(postcss@8.5.13):
+  autoprefixer@10.5.0(postcss@8.5.18):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001791
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.13
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
   axe-core@4.11.4: {}
@@ -3089,7 +3089,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -3244,15 +3244,15 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  postcss-cli@11.0.1(jiti@2.6.1)(postcss@8.5.13):
+  postcss-cli@11.0.1(jiti@2.6.1)(postcss@8.5.18):
     dependencies:
       chokidar: 3.6.0
       dependency-graph: 1.0.0
       fs-extra: 11.3.4
       picocolors: 1.1.1
-      postcss: 8.5.13
-      postcss-load-config: 5.1.0(jiti@2.6.1)(postcss@8.5.13)
-      postcss-reporter: 7.1.0(postcss@8.5.13)
+      postcss: 8.5.18
+      postcss-load-config: 5.1.0(jiti@2.6.1)(postcss@8.5.18)
+      postcss-reporter: 7.1.0(postcss@8.5.18)
       pretty-hrtime: 1.0.3
       read-cache: 1.0.0
       slash: 5.1.0
@@ -3262,38 +3262,38 @@ snapshots:
       - jiti
       - tsx
 
-  postcss-load-config@5.1.0(jiti@2.6.1)(postcss@8.5.13):
+  postcss-load-config@5.1.0(jiti@2.6.1)(postcss@8.5.18):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.4
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.13
+      postcss: 8.5.18
 
-  postcss-reporter@7.1.0(postcss@8.5.13):
+  postcss-reporter@7.1.0(postcss@8.5.18):
     dependencies:
       picocolors: 1.1.1
-      postcss: 8.5.13
+      postcss: 8.5.18
       thenby: 1.4.1
 
-  postcss-safe-parser@7.0.1(postcss@8.5.13):
+  postcss-safe-parser@7.0.1(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.18
 
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-sorting@10.0.0(postcss@8.5.13):
+  postcss-sorting@10.0.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.18
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.13:
+  postcss@8.5.18:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4089,8 +4089,8 @@ snapshots:
 
   stylelint-order@8.1.1(stylelint@17.9.1):
     dependencies:
-      postcss: 8.5.13
-      postcss-sorting: 10.0.0(postcss@8.5.13)
+      postcss: 8.5.18
+      postcss-sorting: 10.0.0(postcss@8.5.18)
       stylelint: 17.9.1
 
   stylelint-prettier@5.0.3(prettier@3.8.3)(stylelint@17.9.1):
@@ -4128,8 +4128,8 @@ snapshots:
       micromatch: 4.0.8
       normalize-path: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.13
-      postcss-safe-parser: 7.0.1(postcss@8.5.13)
+      postcss: 8.5.18
+      postcss-safe-parser: 7.0.1(postcss@8.5.18)
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
       string-width: 8.2.1


### PR DESCRIPTION
Consolidates the open Dependabot PRs into a single release branch and bumps the version to `2.0.1`.

### Superseded updates

| PR | Update |
|----|--------|
| #182 | build(deps-dev): bump postcss from 8.5.13 to 8.5.18 |

### Verification

- `pnpm install --frozen-lockfile` resolves cleanly ✅
- `pnpm test` passes — Stylint reports **0 errors** (9 pre-existing `leadingZero` style warnings, unchanged by this branch) ✅
- `postcss` resolves to 8.5.18 across `autoprefixer`, `postcss-cli` and `postcss-sorting` ✅
